### PR TITLE
update 'create view' to display only one dataset

### DIFF
--- a/sql/12-alter_relationships_create_view.sql
+++ b/sql/12-alter_relationships_create_view.sql
@@ -5,31 +5,43 @@ AS $$
     CREATE OR REPLACE VIEW buildings_bulk_load.added_outlines AS
         SELECT a.bulk_load_outline_id, b.shape
         FROM buildings_bulk_load.added a
-        JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id);
+        JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
+        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
 
     CREATE OR REPLACE VIEW buildings_bulk_load.removed_outlines AS
         SELECT r.building_outline_id, e.shape
         FROM buildings_bulk_load.removed r
-        JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id);
+        JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
+        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
 
     CREATE OR REPLACE VIEW buildings_bulk_load.matched_bulk_load_outlines AS
         SELECT m.bulk_load_outline_id, b.shape
         FROM buildings_bulk_load.matched m
-        JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id);
+        JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
+        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
 
     CREATE OR REPLACE VIEW buildings_bulk_load.related_bulk_load_outlines AS
         SELECT DISTINCT r.bulk_load_outline_id, b.shape
         FROM buildings_bulk_load.related r
-        JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id);
+        JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
+        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
 
     CREATE OR REPLACE VIEW buildings_bulk_load.matched_existing_outlines AS
         SELECT m.building_outline_id, e.shape
         FROM buildings_bulk_load.matched m
-        JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id);
+        JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
+        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
 
     CREATE OR REPLACE VIEW buildings_bulk_load.related_existing_outlines AS
         SELECT DISTINCT r.building_outline_id, e.shape
         FROM buildings_bulk_load.related r
-        JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id);
+        JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
+        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
 
 $$ LANGUAGE sql;

--- a/sql/12-alter_relationships_create_view.sql
+++ b/sql/12-alter_relationships_create_view.sql
@@ -7,41 +7,47 @@ AS $$
         FROM buildings_bulk_load.added a
         JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
         JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
+        WHERE d.processed_date IS NOT NULL
+        AND d.transfer_date IS NULL;
 
     CREATE OR REPLACE VIEW buildings_bulk_load.removed_outlines AS
         SELECT r.building_outline_id, e.shape
         FROM buildings_bulk_load.removed r
         JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
         JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
+        WHERE d.processed_date IS NOT NULL
+        AND d.transfer_date IS NULL;
 
     CREATE OR REPLACE VIEW buildings_bulk_load.matched_bulk_load_outlines AS
         SELECT m.bulk_load_outline_id, b.shape
         FROM buildings_bulk_load.matched m
         JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
         JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
+        WHERE d.processed_date IS NOT NULL
+        AND d.transfer_date IS NULL;
 
     CREATE OR REPLACE VIEW buildings_bulk_load.related_bulk_load_outlines AS
         SELECT DISTINCT r.bulk_load_outline_id, b.shape
         FROM buildings_bulk_load.related r
         JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
         JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
+        WHERE d.processed_date IS NOT NULL
+        AND d.transfer_date IS NULL;
 
     CREATE OR REPLACE VIEW buildings_bulk_load.matched_existing_outlines AS
         SELECT m.building_outline_id, e.shape
         FROM buildings_bulk_load.matched m
         JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
         JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
+        WHERE d.processed_date IS NOT NULL
+        AND d.transfer_date IS NULL;
 
     CREATE OR REPLACE VIEW buildings_bulk_load.related_existing_outlines AS
         SELECT DISTINCT r.building_outline_id, e.shape
         FROM buildings_bulk_load.related r
         JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
         JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date is not NULL AND d.transfer_date is NULL;
+        WHERE d.processed_date IS NOT NULL
+        AND d.transfer_date IS NULL;
 
 $$ LANGUAGE sql;


### PR DESCRIPTION
Fixes: https://github.com/linz/qgis-buildings-plugin/issues/35

### Change Description:

The views created for 'alter-building-relationships' will only display one dataset which is processed but not yet transferred to production.

### Notes for Testing:

run `sudo make install && make check` in this directory  and open the views in `nz-buildings-pgtap-db -> buildings_bulk_load`. The views will only show the supplied_dataset_id: 2 and 4
 
#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
