### PR TITLE
Add on_error_stop in psql command

### DIFF
--- a/scripts/nz-buildings-load.in
+++ b/scripts/nz-buildings-load.in
@@ -90,42 +90,59 @@ psql -c "DROP SCHEMA IF EXISTS buildings_reference CASCADE;"
 psql -c "CREATE EXTENSION IF NOT EXISTS postgis SCHEMA public;"
 psql -c "SET client_min_messages TO WARNING;"
 
+export ON_ERROR_STOP="--set ON_ERROR_STOP=true"
+
+psql_exit() {
+    psql_exit_status=$?
+    if [ "$psql_exit_status" != "0" ]; then
+        exit "$psql_exit_status"
+    fi
+}
+
 # Execute all files in the reference sql dir
 for file in ${SCRIPTSDIR}/sql/reference/*.sql; do
     echo ${file} >&2
-    psql -f ${file}
+    psql -f ${file} $ON_ERROR_STOP
+    psql_exit
 done
 
 # Execute all files in the main sql dir
 for file in ${SCRIPTSDIR}/sql/*.sql; do
     echo ${file} >&2
-    psql -f ${file}
+    psql -f ${file} $ON_ERROR_STOP
+    psql_exit
 done
 
 # Execute all files in the lds sql dir
 for file in ${SCRIPTSDIR}/sql/lds/*.sql; do
     echo ${file} >&2
-    psql -f ${file}
+    psql -f ${file} $ON_ERROR_STOP
+    psql_exit
 done
 
 # Execute files that create test data - test data remains in database
 if [ "${WITH_TEST_DATA}" = true ]; then
     # Execute all files in the test data sql dir
     echo ${SCRIPTSDIR}/tests/testdata/01-insert_test_data_reference.sql >&2
-    psql -f ${SCRIPTSDIR}/tests/testdata/01-insert_test_data_reference.sql
+    psql -f ${SCRIPTSDIR}/tests/testdata/01-insert_test_data_reference.sql $ON_ERROR_STOP
+    psql_exit
     echo ${SCRIPTSDIR}/tests/testdata/02-insert_test_data_buildings_bulk_load.sql >&2
-    psql -f ${SCRIPTSDIR}/tests/testdata/02-insert_test_data_buildings_bulk_load.sql
+    psql -f ${SCRIPTSDIR}/tests/testdata/02-insert_test_data_buildings_bulk_load.sql $ON_ERROR_STOP
+    psql_exit
     psql -c "SELECT buildings_bulk_load.compare_building_outlines(1);"
     psql -c "SELECT buildings_bulk_load.load_building_outlines(1);"
     psql -c "SELECT buildings_bulk_load.create_building_relationship_view();"
     psql -c "SELECT buildings_lds.populate_buildings_lds();"
     echo ${SCRIPTSDIR}/tests/testdata/03-insert_test_data_second_dataset.sql >&2
-    psql -f ${SCRIPTSDIR}/tests/testdata/03-insert_test_data_second_dataset.sql
+    psql -f ${SCRIPTSDIR}/tests/testdata/03-insert_test_data_second_dataset.sql $ON_ERROR_STOP
+    psql_exit
     psql -c "SELECT buildings_bulk_load.compare_building_outlines(2);"
     echo ${SCRIPTSDIR}/tests/testdata/04-insert_test_data_functions.sql >&2
-    psql -f ${SCRIPTSDIR}/tests/testdata/04-insert_test_data_functions.sql
+    psql -f ${SCRIPTSDIR}/tests/testdata/04-insert_test_data_functions.sql $ON_ERROR_STOP
+    psql_exit
     echo ${SCRIPTSDIR}/tests/testdata/05-insert_test_data_complex.sql >&2
-    psql -f ${SCRIPTSDIR}/tests/testdata/05-insert_test_data_complex.sql
+    psql -f ${SCRIPTSDIR}/tests/testdata/05-insert_test_data_complex.sql $ON_ERROR_STOP
+    psql_exit
     psql -c "SELECT buildings_bulk_load.compare_building_outlines(4);"
 
 fi
@@ -133,9 +150,11 @@ fi
 if [ "${WITH_PLUGIN_SETUP}" = true ]; then
     # Execute all files in the test data sql dir
     echo ${SCRIPTSDIR}/tests/testdata/01-insert_test_data_reference.sql >&2
-    psql -f ${SCRIPTSDIR}/tests/testdata/01-insert_test_data_reference.sql
+    psql -f ${SCRIPTSDIR}/tests/testdata/01-insert_test_data_reference.sql $ON_ERROR_STOP
+    psql_exit
     echo ${SCRIPTSDIR}/tests/testdata/06-insert_test_data_buildings_bulk_load_plugin.sql >&2
-    psql -f ${SCRIPTSDIR}/tests/testdata/06-insert_test_data_buildings_bulk_load_plugin.sql
+    psql -f ${SCRIPTSDIR}/tests/testdata/06-insert_test_data_buildings_bulk_load_plugin.sql $ON_ERROR_STOP
+    psql_exit
     psql -c "SELECT buildings_bulk_load.compare_building_outlines(2);"
     psql -c "SELECT buildings_bulk_load.create_building_relationship_view();"
 


### PR DESCRIPTION
Fixes: #135   


### Change Description:

- Modified the `nz-buildings-load`. If there's an error from the sql, the script will catch it and then exit. 

### Notes for Testing:

go to folder and run `sudo make install` and run `nz-buildings-load` on one of your database. `09-buildings_functions.sql` has an error so the process should stop at this.

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
