### PR TITLE
Remove "create views" function

### DIFF
--- a/scripts/nz-buildings-load.in
+++ b/scripts/nz-buildings-load.in
@@ -131,7 +131,6 @@ if [ "${WITH_TEST_DATA}" = true ]; then
     psql_exit
     psql -c "SELECT buildings_bulk_load.compare_building_outlines(1);"
     psql -c "SELECT buildings_bulk_load.load_building_outlines(1);"
-    psql -c "SELECT buildings_bulk_load.create_building_relationship_view();"
     psql -c "SELECT buildings_lds.populate_buildings_lds();"
     echo ${SCRIPTSDIR}/tests/testdata/03-insert_test_data_second_dataset.sql >&2
     psql -f ${SCRIPTSDIR}/tests/testdata/03-insert_test_data_second_dataset.sql $ON_ERROR_STOP
@@ -156,6 +155,5 @@ if [ "${WITH_PLUGIN_SETUP}" = true ]; then
     psql -f ${SCRIPTSDIR}/tests/testdata/06-insert_test_data_buildings_bulk_load_plugin.sql $ON_ERROR_STOP
     psql_exit
     psql -c "SELECT buildings_bulk_load.compare_building_outlines(2);"
-    psql -c "SELECT buildings_bulk_load.create_building_relationship_view();"
 
 fi

--- a/sql/12-alter_relationships_create_view.sql
+++ b/sql/12-alter_relationships_create_view.sql
@@ -1,53 +1,47 @@
-CREATE OR REPLACE FUNCTION buildings_bulk_load.create_building_relationship_view()
-    RETURNS void
-AS $$
+CREATE OR REPLACE VIEW buildings_bulk_load.added_outlines AS
+    SELECT a.bulk_load_outline_id, b.shape
+    FROM buildings_bulk_load.added a
+    JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
+    JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+    WHERE d.processed_date IS NOT NULL
+    AND d.transfer_date IS NULL;
 
-    CREATE OR REPLACE VIEW buildings_bulk_load.added_outlines AS
-        SELECT a.bulk_load_outline_id, b.shape
-        FROM buildings_bulk_load.added a
-        JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
-        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date IS NOT NULL
-        AND d.transfer_date IS NULL;
+CREATE OR REPLACE VIEW buildings_bulk_load.removed_outlines AS
+    SELECT r.building_outline_id, e.shape
+    FROM buildings_bulk_load.removed r
+    JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
+    JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+    WHERE d.processed_date IS NOT NULL
+    AND d.transfer_date IS NULL;
 
-    CREATE OR REPLACE VIEW buildings_bulk_load.removed_outlines AS
-        SELECT r.building_outline_id, e.shape
-        FROM buildings_bulk_load.removed r
-        JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
-        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date IS NOT NULL
-        AND d.transfer_date IS NULL;
+CREATE OR REPLACE VIEW buildings_bulk_load.matched_bulk_load_outlines AS
+    SELECT m.bulk_load_outline_id, b.shape
+    FROM buildings_bulk_load.matched m
+    JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
+    JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+    WHERE d.processed_date IS NOT NULL
+    AND d.transfer_date IS NULL;
 
-    CREATE OR REPLACE VIEW buildings_bulk_load.matched_bulk_load_outlines AS
-        SELECT m.bulk_load_outline_id, b.shape
-        FROM buildings_bulk_load.matched m
-        JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
-        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date IS NOT NULL
-        AND d.transfer_date IS NULL;
+CREATE OR REPLACE VIEW buildings_bulk_load.related_bulk_load_outlines AS
+    SELECT DISTINCT r.bulk_load_outline_id, b.shape
+    FROM buildings_bulk_load.related r
+    JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
+    JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+    WHERE d.processed_date IS NOT NULL
+    AND d.transfer_date IS NULL;
 
-    CREATE OR REPLACE VIEW buildings_bulk_load.related_bulk_load_outlines AS
-        SELECT DISTINCT r.bulk_load_outline_id, b.shape
-        FROM buildings_bulk_load.related r
-        JOIN buildings_bulk_load.bulk_load_outlines b USING (bulk_load_outline_id)
-        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date IS NOT NULL
-        AND d.transfer_date IS NULL;
+CREATE OR REPLACE VIEW buildings_bulk_load.matched_existing_outlines AS
+    SELECT m.building_outline_id, e.shape
+    FROM buildings_bulk_load.matched m
+    JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
+    JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+    WHERE d.processed_date IS NOT NULL
+    AND d.transfer_date IS NULL;
 
-    CREATE OR REPLACE VIEW buildings_bulk_load.matched_existing_outlines AS
-        SELECT m.building_outline_id, e.shape
-        FROM buildings_bulk_load.matched m
-        JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
-        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date IS NOT NULL
-        AND d.transfer_date IS NULL;
-
-    CREATE OR REPLACE VIEW buildings_bulk_load.related_existing_outlines AS
-        SELECT DISTINCT r.building_outline_id, e.shape
-        FROM buildings_bulk_load.related r
-        JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
-        JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
-        WHERE d.processed_date IS NOT NULL
-        AND d.transfer_date IS NULL;
-
-$$ LANGUAGE sql;
+CREATE OR REPLACE VIEW buildings_bulk_load.related_existing_outlines AS
+    SELECT DISTINCT r.building_outline_id, e.shape
+    FROM buildings_bulk_load.related r
+    JOIN buildings_bulk_load.existing_subset_extracts e USING (building_outline_id)
+    JOIN buildings_bulk_load.supplied_datasets d USING (supplied_dataset_id)
+    WHERE d.processed_date IS NOT NULL
+    AND d.transfer_date IS NULL;

--- a/tests/buildings_bulk_load_create_view.pg
+++ b/tests/buildings_bulk_load_create_view.pg
@@ -19,49 +19,44 @@ BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
 
-SELECT plan(7);
+SELECT plan(6);
 
 --1----------------------------------------------------------
--- Check function exists
-
-SELECT has_function('buildings_bulk_load', 'create_building_relationship_view', 'Should have function create_building_relationship_view in buildings_bulk_load schema.');
-
---2----------------------------------------------------------
 -- Check view added_outlines exists
 
 SELECT has_view('buildings_bulk_load', 'added_outlines',
     'Should have added_outlines view in the buildings_bulk_load schema.'
 );
 
---3----------------------------------------------------------
+--2----------------------------------------------------------
 -- Check view removed_outlines exists
 
 SELECT has_view('buildings_bulk_load', 'removed_outlines',
     'Should have removed_outlines view in the buildings_bulk_load schema.'
 );
 
---4----------------------------------------------------------
+--3----------------------------------------------------------
 -- Check view matched_bulk_load_outlines exists
 
 SELECT has_view('buildings_bulk_load', 'matched_bulk_load_outlines',
     'Should have matched_bulk_load_outlines view in the buildings_bulk_load schema.'
 );
 
---5----------------------------------------------------------
+--4----------------------------------------------------------
 -- Check view related_bulk_load_outlines exists
 
 SELECT has_view('buildings_bulk_load', 'related_bulk_load_outlines',
     'Should have related_bulk_load_outlines view in the buildings_bulk_load schema.'
 );
 
---6----------------------------------------------------------
+--5----------------------------------------------------------
 -- Check view matched_existing_outlines exists
 
 SELECT has_view('buildings_bulk_load', 'matched_existing_outlines',
     'Should have matched_existing_outlines view in the buildings_bulk_load schema.'
 );
 
---7----------------------------------------------------------
+--6----------------------------------------------------------
 -- Check view related_existing_outlines exists
 
 SELECT has_view('buildings_bulk_load', 'related_existing_outlines',


### PR DESCRIPTION
Fixes: #141 

### Change Description:

Remove the function `buildings_bulk_load.create_building_relationship_view()`. The script will create views directly instead of create the function.

### Notes for Testing:

Steps to reproduce the behavior:

1. Run nz-buildings-load [database] to create a empty database
2. Open database and there should be views created in the buildings_bulk_load schema


#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
