### PR TITLE
remove `st_expand` in town/city intersecting function

### DIFF
--- a/sql/08-admin_boundary_functions.sql
+++ b/sql/08-admin_boundary_functions.sql
@@ -57,10 +57,9 @@ $$
 
     SELECT town_city_id
     FROM buildings_reference.town_city
-    WHERE shape && ST_Expand(p_polygon_geometry, 1000)
+    WHERE ST_Intersects(shape, p_polygon_geometry)
     ORDER BY
-          ST_Area(ST_Intersection(p_polygon_geometry, shape)) / ST_Area(shape) DESC
-        , ST_Distance(p_polygon_geometry, shape) ASC
+          ST_Area(ST_Intersection(p_polygon_geometry, shape)) DESC
     LIMIT 1;
 
 $$

--- a/tests/admin_boundary_functions.pg
+++ b/tests/admin_boundary_functions.pg
@@ -47,13 +47,13 @@ SELECT results_eq(
 SELECT has_function('buildings', 'town_city_intersect_polygon', 'Should have function nz_locality_town_city_intersect_polygon in buildings schema.');
 SELECT results_eq(
 	$$SELECT buildings.town_city_intersect_polygon('01060000209108000001000000010300000001000000050000000000000028A83C41000000C0263155410000000028A83C410000000019315541000000008CA83C410000000019315541000000008CA83C41000000C0263155410000000028A83C41000000C026315541');$$,
-    $$VALUES (200)$$,
+    $$VALUES (100)$$,
     'town_city_intersect_polygon not returning correct town_city_id value when building intersects town_city polygon'
 );
 
 SELECT results_eq(
     $$SELECT buildings.town_city_intersect_polygon('01030000209108000001000000050000003460F2F8D9A93C417F87C576D7305541D6ECEDF2DAA93C41C1E8E623D0305541569A5626FCA93C4112AFE4A0D030554170F46338F9A93C412EC1C7F9D63055413460F2F8D9A93C417F87C576D7305541');$$,
-    $$VALUES (400)$$,
+    $$VALUES (NULL::integer)$$,
     'town_city_intersect_polygon not returning correct town_city_id value when building is outside town_city polygon'
 );
 


### PR DESCRIPTION
Related to https://github.com/linz/qgis-buildings-plugin/pull/82

### Change Description:
remove `st_expand` in town/city intersecting function