### PR TITLE
Specify schema for installation of intarray extension

### DIFF
--- a/scripts/nz-buildings-load.in
+++ b/scripts/nz-buildings-load.in
@@ -89,7 +89,7 @@ psql -c "DROP SCHEMA IF EXISTS buildings_reference CASCADE;"
 
 psql -c "CREATE EXTENSION IF NOT EXISTS postgis SCHEMA public;"
 # intarray is used in compare_buildings.sql for array sorting
-psql -c "CREATE EXTENSION IF NOT EXISTS intarray;"
+psql -c "CREATE EXTENSION IF NOT EXISTS intarray SCHEMA public;"
 psql -c "SET client_min_messages TO WARNING;"
 
 export ON_ERROR_STOP="--set ON_ERROR_STOP=true"

--- a/tests/extensions.pg
+++ b/tests/extensions.pg
@@ -1,0 +1,44 @@
+------------------------------------------------------------------------------
+-- Provide unit testing for extensions using pgTAP
+------------------------------------------------------------------------------
+
+-- Turn off echo.
+\set QUIET 1
+
+-- Format the output nicely.
+\pset format unaligned
+\pset tuples_only true
+\pset pager
+
+-- Revert all changes on failure.
+\set ON_ERROR_ROLLBACK 1
+\set ON_ERROR_STOP true
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+
+
+SELECT plan(2);
+
+-- Tests
+
+--intarray--------------------------
+SELECT has_extension(
+    'public',
+    'intarray',
+    'Schema public should have the intarray extension.'
+);
+
+--PostGIS--------------------------
+SELECT has_extension(
+    'public',
+    'postgis',
+    'Schema public should have the PostGIS extension.'
+);
+
+
+-- Finish pgTAP testing
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
Fixes: #154 

### Change Description:

Clarify that `intarray` should be installed in the `public` schema.

### Notes for Testing:

- New `extensions.pg` file added to test suite that checks existence of extensions.

#### Testing Tasks:
- [x] Added tests that fail without this change
- [x] All tests are passing in development environment
- [x] Reviewers assigned
- [x] Linked to main issue for ZenHub board
