### PR TITLE
function to delete from deleted table

### DIFF
--- a/sql/buildings_bulk_load/functions/12-deletion_description.sql
+++ b/sql/buildings_bulk_load/functions/12-deletion_description.sql
@@ -3,6 +3,10 @@
 
 -- Functions:
 
+-- delete_deleted_description (delete record from deletion description table)
+    -- params: integer bulk_load_outline_id
+    -- return: integer bulk_load_outline_id
+
 -- deletion_description_insert (create new record in deletion description)
 	-- params: integer bulk_load_outline_id varchar(250) description
 	-- return: integer bulk_load_outline_id
@@ -10,6 +14,23 @@
 --------------------------------------------
 
 -- Functions
+
+-- delete_deleted_description (delete record from deletion description table)
+    -- params: integer bulk_load_outline_id
+    -- return: integer bulk_load_outline_id
+CREATE OR REPLACE FUNCTION buildings_bulk_load.delete_deleted_description(integer)
+RETURNS integer AS
+$$
+    DELETE
+    FROM buildings_bulk_load.deletion_description
+    WHERE bulk_load_outline_id = $1
+    RETURNING deletion_description.bulk_load_outline_id;
+
+$$
+LANGUAGE sql;
+
+COMMENT ON FUNCTION buildings_bulk_load.delete_deleted_description(integer) IS
+'Delete record from deletion description table';
 
 
 -- deletion_description_insert (create new record in deletion description)


### PR DESCRIPTION
Fixes: https://github.com/linz/qgis-buildings-plugin/issues/138

### Change Description:
delete_deleted_description function added to all for the reversion of deleting building outlines

### Notes for Testing:


#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
